### PR TITLE
club requests to be made with id instead of name

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -142,7 +142,7 @@ export default class BounceClient {
      * @param {String} fullName Optional, may be undefined
      * @param {String} email Optional, may be undefined
      * @param {String} bio Optional, may be undefined
-     * @param {String} password Optional, may be undefined
+     * @param {String} password
      */
     async updateUser(username, fullName, email, password, bio) {
         let body = {};
@@ -171,33 +171,32 @@ export default class BounceClient {
 
     /**
      * Fetch information about a club
-     * @param {String} name
+     * @param {String} id
      */
-    async getClub(name) {
-        return await this._request('GET', '/clubs/' + name);
+    async getClub(id) {
+        return await this._request('GET', '/clubs/' + id);
     }
 
     /**
      * Returns a list of clubs that match the given query.
      * @param {String} query
      */
-    async searchClubs(query) {
-        if (!query) return await this._request('GET', '/clubs/search');
-        return await this._request('GET', `/clubs/search?query=${query}`);
+    async searchClubs(params) {
+        return await this._request('GET', '/clubs/search', null, params);
     }
 
     /**
      * Create a new club with the given properties
-     * @param {String} name
+     * @param {String} id
      * @param {String} description
      * @param {String} websiteUrl
      * @param {String} facebookUrl
      * @param {String} instagramUrl
      * @param {String} twitterUrl
      */
-    async createClub(name, description, websiteUrl, facebookUrl, instagramUrl, twitterUrl) {
+    async createClub(id, description, websiteUrl, facebookUrl, instagramUrl, twitterUrl) {
         return await this._request('POST', '/clubs', {
-            name: name,
+            id: id,
             description: description,
             website_url: websiteUrl,
             facebook_url: facebookUrl,
@@ -216,7 +215,7 @@ export default class BounceClient {
      * @param {String} instagramUrl (optional) The club's new instagramUrl
      * @param {String} twitterUrl (optional) The club's new twitterUrl
      */
-    async updateClub(name, newName, description, websiteUrl, facebookUrl, instagramUrl, twitterUrl) {
+    async updateClub(id, newName, description, websiteUrl, facebookUrl, instagramUrl, twitterUrl) {
         const attrs = {
             name: newName,
             description: description,
@@ -231,38 +230,38 @@ export default class BounceClient {
                 delete attrs[attr];
             }
         }
-        return await this._request('PUT', '/clubs/' + name, attrs);
+        return await this._request('PUT', '/clubs/' + id, attrs);
     }
 
     /**
      * Delete the club with the given name
      * @param {String} name
      */
-    async deleteClub(name) {
-        return await this._request('DELETE', '/clubs/' + name);
+    async deleteClub(id) {
+        return await this._request('DELETE', '/clubs/' + id);
     }
 
     /**
      * Fetches the memberships for the given club. If a userId is provided only
      * the membership for that user will be returned.
-     * @param {String} clubName
+     * @param {String} clubID
      * @param {String} userId (optional, may be undefined)
      */
-    async getMemberships(clubName, userId) {
+    async getMemberships(clubID, userId) {
         const params = userId ? { user_id: userId } : undefined;
-        return await this._request('GET', `/memberships/${clubName}`,
+        return await this._request('GET', `/memberships/${clubID}`,
             undefined, params);
     }
 
     /**
      * Deletes the memberships for the given club. If a userId is provided only
      * the membership for that user will be deleted.
-     * @param {String} clubName
+     * @param {String} clubID
      * @param {String} userId (optional, may be undefined)
      */
-    async deleteMemberships(clubName, userId) {
+    async deleteMemberships(clubID, userId) {
         const params = userId ? { user_id: userId } : undefined;
-        return await this._request('DELETE', `/memberships/${clubName}`,
+        return await this._request('DELETE', `/memberships/${clubID}`,
             undefined, params);
     }
 }

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -77,10 +77,10 @@ class App extends Component {
      * @param {Object} filter provides the club name based on the URI
      */
     getViewClubPage(filter) {
-        const name = decodeURIComponent(filter.match.params.name);
+        const id = decodeURIComponent(filter.match.params.id);
         return <ViewClub
             client={this.props.client}
-            name={name}
+            id={id}
         />;
     }
 
@@ -117,7 +117,7 @@ class App extends Component {
                         <Route exact path='/' render={this.getHomePage} />
                         <Route path='/sign-in' render={this.getSignInPage} />
                         <Route path='/create-club' render={this.getCreateClubPage} />
-                        <Route path='/clubs/:name' component={this.getViewClubPage} />
+                        <Route path='/clubs/:id' component={this.getViewClubPage} />
                         <Route path='/create-account' render={this.getCreateAccountPage} />
                         <Route path='/account-settings' render={this.getAccountSettingsPage} />
                         <Route path='*' render={() => <Redirect to='/' />} />

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -113,13 +113,13 @@ class BounceNavbar extends Component {
     }
 
     search() {
-        this.props.client.searchClubs(this.props.searchQuery)
+        this.props.client.searchClubs({name:this.props.searchQuery, description:this.props.searchQuery})
             .then(result => {
                 if (result.ok) {
                     // Display results
                     result.json().then(body => {
                         this.props.changeClubs(body.results.map(item => {
-                            return Object.assign(item, {link: `/clubs/${item.name}`});
+                            return Object.assign(item, {link: `/clubs/${item.id}`});
                         }));
                         // Trigger redirect to Home page so it can display search results
                         this.setState({ goToHome: true });

--- a/src/components/clubs/ViewClub.js
+++ b/src/components/clubs/ViewClub.js
@@ -54,7 +54,7 @@ class ViewClub extends Component {
      */
     componentDidMount() {
         // Fetch the club's info after rendering
-        this.props.client.getClub(this.props.name)
+        this.props.client.getClub(this.props.id)
             .then(response => {
                 if (response.ok) {
                     response.json().then(body => {
@@ -89,7 +89,7 @@ class ViewClub extends Component {
                 return;
             });
 
-        this.props.client.getMemberships(this.props.name).then(response => {
+        this.props.client.getMemberships(this.props.id).then(response => {
             if (response.ok) {
                 response.json().then(body => {
                     // Check if we're a president or admin of this club
@@ -124,7 +124,7 @@ class ViewClub extends Component {
     handleSubmit(event) {
         event.preventDefault();
         this.props.client.updateClub(
-            this.props.name,
+            this.props.id,
             this.state.name,
             this.state.description,
             this.state.websiteUrl,


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #
Update front-end api client to use id in clubs urls instead of club name #141
---

## :construction_worker: Changes

- replaced the "name" with "id" when making requests in api.js
- made similar changes in viewclub.js

## :traffic_light: Concerns
Make sure it is up to date with master, had some weird behavior after pulling where the Bio fields in api.js were removed completely.

## :mag: Testing Instructions

when searching for a club on the front end, see if the URL displays "club/1" instead of club/launchpad
